### PR TITLE
Example of faster createTextLayerInSelection

### DIFF
--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -145,7 +145,7 @@ const getDefaultStyle = () => {
         "layerText": {
             "textGridding":"none",
             "orientation":"horizontal",
-            "antiAlias":"antiAliasCrisp",
+            "antiAlias":"antiAliasSmooth",
             "textStyleRange":[{
                 "from":0,
                 "to":100,
@@ -186,7 +186,8 @@ const getDefaultStyle = () => {
                     "justificationMethodType":"justifMethodAutomatic",
                     "textEveryLineComposer":false,
                     "alignment":"center",
-                    "hangingRoman":true
+                    "hangingRoman":true,
+                    "hyphenate": true
                 }
             }]
         },


### PR DESCRIPTION
This is an example of a faster createTextLayerInSelection. It's fairly rough at the moment, I took a peak at jamText, but I didn't really look at much else, there's likely a better way of integrating it with the rest of the jam library. I defaulted to my own action manager functions, since I'm not familiar with that library.

Also, it would be better if the functions could be wrapped in activeDocument.suspendHistory, but I'm not sure if that's possible as an extension or not. I failed to get it working within createTextLayerInselection, it might be possible within the event that fires it? It would better to use suspendHistory for your events if possible, all the changes fired by them would be contained within one "action" in Photoshop's history. Making it much easier to undo/redo. In addition, suspendHistory will pause Photoshop's rendering and each individual action won't need to be drawn.